### PR TITLE
Fix project reviews migration

### DIFF
--- a/app/database/migrations/20200530000000_project_reviews.js
+++ b/app/database/migrations/20200530000000_project_reviews.js
@@ -7,12 +7,12 @@ exports.up = function(knex) {
         table.integer("supporter_communication").notNullable();
         table.integer("provided_value").notNullable();
         table.integer("supporter_user_id")
-            .references("supporters.sup_id")
+            .references("supporters.id")
             .onDelete("CASCADE")
             .onUpdate("CASCADE"); 
         table.integer("conservationist_user_id")
             .notNullable()
-            .references("conservationists.cons_id")
+            .references("conservationists.id")
             .onDelete("CASCADE")
             .onUpdate("CASCADE");   
         table.integer("skilled_impact_request_id")


### PR DESCRIPTION
This migration was created before the refactor, but landed after the
refactor. Since it relied on column names that were changed in the
refactor, it works when migrating on a clean database but not on an
existing database.

Fixed by advancing the migration date to today, 5/30/2020.